### PR TITLE
Fix dynamic_config definition in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,9 @@ my %WriteMakefileArgs = (
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'String-Mask-*' },
-    dynamic_config => 0,
+    META_MERGE => {
+        dynamic_config => 0,
+    },
 );
 
 # Compatibility with old versions of ExtUtils::MakeMaker


### PR DESCRIPTION
dynamic_config is a meta key, not a EUMM configuration option. Move it into a `META_MERGE` section.

Fixes #1